### PR TITLE
Enable to build Kalzium with GCC Address Sanitizer.

### DIFF
--- a/libscience/psetables.h
+++ b/libscience/psetables.h
@@ -101,7 +101,7 @@ private:
  * defines a Periodic Table.
  * Holds the position (x,y) and all the displayed elements
  */
-class pseTable
+class SCIENCE_EXPORT pseTable
 
 {
 public:


### PR DESCRIPTION
Hello,

this patch resolves undefined references to
pseTable when Kalzium is built with libasan.

Thanks,
Libor
