### PR TITLE
fix discarded-qualifiers errors

### DIFF
--- a/src/solver/modwrap.c
+++ b/src/solver/modwrap.c
@@ -27,7 +27,7 @@
 
 char* solve_equation(const char *eq)
 {
-    static value *solve_equation_closure = NULL;
+    static const value *solve_equation_closure = NULL;
     if (solve_equation_closure == NULL) {
         solve_equation_closure = caml_named_value("solve_equation");
     }


### PR DESCRIPTION
Since OCaml 4.09 caml_named_value() returns 'const value *'.

[ 64%] Generating modwrap.o
cd /home/abuild/rpmbuild/BUILD/kalzium-20.04.3/build/src && /usr/bin/ocamlopt -I /usr/lib/ocaml/facile -c /home/abuild/rpmbuild/BUILD/kalzium-20.04.3/src/solver/modwrap.c
/home/abuild/rpmbuild/BUILD/kalzium-20.04.3/src/solver/modwrap.c: In function 'solve_equation':
/home/abuild/rpmbuild/BUILD/kalzium-20.04.3/src/solver/modwrap.c:32:32: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
   32 |         solve_equation_closure = caml_named_value("solve_equation");
      |                                ^
cc1: some warnings being treated as errors
make[2]: *** [src/CMakeFiles/kalzium.dir/build.make:121: src/modwrap.o] Error 2

Signed-off-by: Olaf Hering <olaf@aepfle.de>